### PR TITLE
update img overlay, title img for mobile, version changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.1.9] - 2025-5-01
+
+### Changed
+
+- updated image overlay to be bigger, decreased image title text when the view is 400px
+
 ## [0.1.8] - 2025-4-29
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "franchineninh",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "franchineninh",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-brands-svg-icons": "^6.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "franchineninh",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "homepage": "https://franchine.github.io/",
   "private": false,
   "dependencies": {

--- a/src/css/Gallery.css
+++ b/src/css/Gallery.css
@@ -69,6 +69,7 @@
   color: plum;
   display: flex;
   flex-direction: column;
+  height: 60px;
   justify-content: center;
   left: 0;
   opacity: 0; 
@@ -175,5 +176,9 @@
 @media (max-width: 400px) {
   .galleryWrap {
     column-count: 1;
+  }
+
+  .image-title {
+    font-size: 0.5em;
   }
 }


### PR DESCRIPTION
## [0.1.9] - 2025-5-01

### Changed

- updated image overlay to be bigger, decreased image title text when the view is 400px